### PR TITLE
Refactor draggable version history

### DIFF
--- a/components/DragWindow.js
+++ b/components/DragWindow.js
@@ -1,38 +1,34 @@
-import React, { useEffect, useState } from "react"
-import { motion } from "framer-motion"
+import React, { useState } from "react"
 import cx from "classnames"
+import { useDrag } from "utils/contexts/DragContext"
+import useWindowSize from "utils/hooks/UseWindowSize"
 
 const DragWindow = ({ children }) => {
-  const [windowWidth, setWindowWidth] = useState(null)
-  const [dragging, setDragging] = useState(0)
+  const size = useWindowSize()
+  const { dragPosition, setDragPosition, dragging, setDragging } = useDrag()
   const [startPosition, setStartPosition] = useState(0)
-  const [rightPosition, setRightPosition] = useState(0)
-
-  useEffect(() => {
-    setWindowWidth(window.innerWidth)
-  }, [])
 
   const calculateRightPosition = (eventX) => {
     const dontTransitionFromRight =
-      startPosition === windowWidth && eventX > windowWidth * 0.9
+      startPosition === size.width && eventX > size.width * 0.9
     const doTransitionFromLeft =
-      startPosition !== windowWidth && eventX > windowWidth * 0.1
-    if (dontTransitionFromRight || doTransitionFromLeft) return windowWidth
+      startPosition !== size.width && eventX > size.width * 0.1
+    if (dontTransitionFromRight || doTransitionFromLeft) return size.width
 
     return 0
   }
 
   const handler = () => {
-    setStartPosition(rightPosition)
+    setStartPosition(dragPosition)
 
     const onMouseMove = (mouseMoveEvent) => {
       setDragging(true)
-      setRightPosition(mouseMoveEvent.pageX)
+      setDragPosition(mouseMoveEvent.pageX)
     }
 
     const onMouseUp = (mouseMoveEvent) => {
       setDragging(false)
-      setRightPosition(calculateRightPosition(mouseMoveEvent.pageX))
+      setDragPosition(calculateRightPosition(mouseMoveEvent.pageX))
       document.body.removeEventListener("mousemove", onMouseMove)
       document.body.removeEventListener("mouseup", onMouseUp)
     }
@@ -41,11 +37,11 @@ const DragWindow = ({ children }) => {
     document.body.addEventListener("mouseup", onMouseUp)
   }
   return (
-    <motion.div
+    <div
       className={cx("relative z-20", {
         ["transition-all duration-500 ease-in-out"]: !dragging,
       })}
-      style={{ right: -rightPosition }}
+      style={{ right: -dragPosition }}
     >
       <button
         id="draghandle"
@@ -53,14 +49,14 @@ const DragWindow = ({ children }) => {
         className={cx(
           "absolute inset-y-0 left-0 z-10 cursor-ew-resize items-center px-2 sm:flex",
           {
-            ["-left-5"]: rightPosition === windowWidth,
+            ["-left-5"]: dragPosition === size.width,
           }
         )}
       >
         <div className="h-8 w-1.5 rounded-full bg-slate-400"></div>
       </button>
       {children}
-    </motion.div>
+    </div>
   )
 }
 export default DragWindow

--- a/components/Modal.js
+++ b/components/Modal.js
@@ -1,5 +1,4 @@
 import React from "react"
-import { motion } from "framer-motion"
 
 const Modal = ({ children, show, onClick, cta }) => {
   if (!show) return null
@@ -14,21 +13,9 @@ const Modal = ({ children, show, onClick, cta }) => {
         role="dialog"
         aria-modal="true"
       >
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.3 }}
-          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
-        ></motion.div>
+        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
 
-        <motion.div
-          initial={{ opacity: 0, scale: 0.5 }}
-          animate={{ opacity: 1, scale: 1 }}
-          exit={{ opacity: 0, scale: 0.5 }}
-          transition={{ duration: 0.3, delay: 0.3 }}
-          className="fixed inset-0 z-10 overflow-y-auto"
-        >
+        <div className="fixed inset-0 z-10 overflow-y-auto">
           <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
             <div className="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-sm sm:p-8">
               <div className="">{children}</div>
@@ -43,7 +30,7 @@ const Modal = ({ children, show, onClick, cta }) => {
               </div>
             </div>
           </div>
-        </motion.div>
+        </div>
       </div>
     </div>
   )

--- a/components/VersionHistory.js
+++ b/components/VersionHistory.js
@@ -5,7 +5,7 @@ const VersionHistory = ({ children }) => {
   const [showModal, setShowModal] = useState(true)
 
   return (
-    <div className="absolute top-0 left-0 h-full w-full overflow-hidden">
+    <div className="absolute top-0 left-0 w-full overflow-hidden">
       <Modal
         cta="Look around"
         onClick={() => setShowModal(false)}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,6 +7,7 @@ import Script from "next/script"
 import { useRouter } from "next/router"
 import * as gtag from "../lib/gtag"
 import { AppearanceProvider } from "utils/contexts/AppearanceContext"
+import { DragProvider } from "utils/contexts/DragContext"
 import cx from "classnames"
 
 function MyApp({ Component, pageProps }) {
@@ -41,13 +42,17 @@ function MyApp({ Component, pageProps }) {
           `,
         }}
       />
-      <AppearanceProvider>
-        {({ darkModeEnabled }) => (
-          <div className={cx("bg-white", { "dark bg-black": darkModeEnabled })}>
-            <Component {...pageProps} />
-          </div>
-        )}
-      </AppearanceProvider>
+      <DragProvider>
+        <AppearanceProvider>
+          {({ darkModeEnabled }) => (
+            <div
+              className={cx("bg-white", { "dark bg-black": darkModeEnabled })}
+            >
+              <Component {...pageProps} />
+            </div>
+          )}
+        </AppearanceProvider>
+      </DragProvider>
     </>
   )
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,21 +1,43 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import V1Page from "components/v1/Home/Home"
 import V2Page from "components/v2/Home/Home"
 import { getCurrentBooksFromOku } from "lib/oku"
 import DragWindow from "components/DragWindow"
 import VersionHistory from "components/VersionHistory"
+import useWindowSize from "utils/hooks/UseWindowSize"
+import { useDrag } from "utils/contexts/DragContext"
 
 const Home = ({ books }) => {
-  return (
-    <div>
-      <DragWindow>
-        <V2Page />
-      </DragWindow>
+  const size = useWindowSize()
+  const { dragPosition } = useDrag()
+  const [showVersionHistory, setShowVersionHistory] = useState(false)
 
-      <VersionHistory>
-        <V1Page books={books} />
-      </VersionHistory>
-    </div>
+  useEffect(() => {
+    if (dragPosition === 0) {
+      setTimeout(() => setShowVersionHistory(false), 500)
+    } else {
+      setShowVersionHistory(true)
+    }
+  }, [dragPosition])
+
+  return (
+    <>
+      {size.width >= 768 ? (
+        <div className="overflow-x-hidden">
+          <DragWindow>
+            <V2Page />
+          </DragWindow>
+
+          {showVersionHistory && (
+            <VersionHistory>
+              <V1Page books={books} />
+            </VersionHistory>
+          )}
+        </div>
+      ) : (
+        <V2Page />
+      )}
+    </>
   )
 }
 

--- a/utils/contexts/DragContext.js
+++ b/utils/contexts/DragContext.js
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState, useEffect } from "react"
+
+export const DragContext = createContext({
+  dragPosition: true,
+  setDragPosition: () => {},
+  dragging: false,
+  setDragging: () => {},
+})
+
+export const useDrag = () => useContext(DragContext)
+
+export const DragProvider = ({ children }) => {
+  const [dragPosition, setDragPosition] = useState(0)
+  const [dragging, setDragging] = useState(0)
+
+  return (
+    <DragContext.Provider
+      value={{ dragPosition, setDragPosition, dragging, setDragging }}
+    >
+      {children}
+    </DragContext.Provider>
+  )
+}


### PR DESCRIPTION
- Refactors the `DragWindow` component to use the existing `useWindowSize` hook
- Stops users from being able to scroll the latest version back into view

https://user-images.githubusercontent.com/32043941/178473676-88bb72eb-34ce-4cef-bf8f-2084de3c7b77.mp4

